### PR TITLE
fix(ci): improve Vercel production deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -26,9 +30,8 @@ jobs:
       - name: Install Vercel CLI
         run: npm install -g vercel
 
+      - name: Pull Vercel Project Settings
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
       - name: Deploy to Vercel
-        run: |
-          vercel deploy ./build/web \
-            --prod \
-            --yes \
-            --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy ./build/web --prod --yes --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,4 +27,8 @@ jobs:
         run: npm install -g vercel
 
       - name: Deploy to Vercel
-        run: vercel deploy ./build/web --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: |
+          vercel deploy ./build/web \
+            --prod \
+            --yes \
+            --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary
- Add non-interactive Vercel deployment using `--yes`
- Add `vercel pull` before deployment
- Use repository Vercel configuration during CI/CD
- Improve production deployment reliability

## Result
Production deployments from the `main` branch can run automatically without manual confirmation prompts.